### PR TITLE
Remove mandatory flags of "key" and "cert" fields in container_push rule

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -116,8 +116,8 @@ container_push = rule(
                 "Docker",
             ],
         ),
-        "key": attr.string(mandatory = True),
-        "cert": attr.string(mandatory = True),
+        "key": attr.string(),
+        "cert": attr.string(),
         "domain": attr.string(),
         "_tag_tpl": attr.label(
             default = Label("//container:push-tag.sh.tpl"),


### PR DESCRIPTION
We would like to add a new bazel rule that pushes docker images to Azure Container Registry. Since acr doesn't support credentials as a method of authentication, we need to remove the mandatory flags of "key" and "cert" fields.