### PR TITLE
Bazel 3.2 Compatibility Fixes

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -15,7 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(["push-tag.sh.tpl"])
 
@@ -141,7 +141,7 @@ py_test(
     deps = ["@containerregistry"],
 )
 
-skylark_library(
+bzl_library(
     name = "bundle",
     srcs = ["bundle.bzl"],
     deps = [
@@ -150,7 +150,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "container",
     srcs = ["container.bzl"],
     deps = [
@@ -162,7 +162,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "flatten",
     srcs = ["flatten.bzl"],
     deps = [
@@ -171,7 +171,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "image",
     srcs = ["image.bzl"],
     deps = [
@@ -185,7 +185,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "import",
     srcs = ["import.bzl"],
     deps = [
@@ -197,24 +197,24 @@ skylark_library(
     ],
 )
 
-skylark_library(
+bzl_library(
     name = "layers",
     srcs = ["layers.bzl"],
     deps = ["//skylib:path"],
 )
 
-skylark_library(
+bzl_library(
     name = "load",
     srcs = ["load.bzl"],
     deps = [":pull"],
 )
 
-skylark_library(
+bzl_library(
     name = "pull",
     srcs = ["pull.bzl"],
 )
 
-skylark_library(
+bzl_library(
     name = "push",
     srcs = ["push.bzl"],
     deps = [

--- a/container/container.bzl
+++ b/container/container.bzl
@@ -13,18 +13,27 @@
 # limitations under the License.
 """Rules for manipulation container images."""
 
-load("//container:bundle.bzl", "container_bundle")
-load("//container:flatten.bzl", "container_flatten")
-load("//container:image.bzl", "container_image", "image")
-load("//container:import.bzl", "container_import")
-load("//container:load.bzl", "container_load")
-load("//container:pull.bzl", "container_pull")
-load("//container:push.bzl", "container_push")
+load("//container:bundle.bzl", _container_bundle = "container_bundle")
+load("//container:flatten.bzl", _container_flatten = "container_flatten")
+load("//container:image.bzl", _container_image = "container_image", "image")
+load("//container:import.bzl", _container_import = "container_import")
+load("//container:load.bzl", _container_load = "container_load")
+load("//container:pull.bzl", _container_pull = "container_pull")
+load("//container:push.bzl", _container_push = "container_push")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 container = struct(
     image = image,
 )
+
+# Re-export imports
+container_bundle = _container_bundle
+container_flatten = _container_flatten
+container_image = _container_image
+container_import = _container_import
+container_load = _container_load
+container_pull = _container_pull
+container_push = _container_push
 
 # The release of the github.com/google/containerregistry to consume.
 CONTAINERREGISTRY_RELEASE = "v0.0.25"

--- a/container/flatten.bzl
+++ b/container/flatten.bzl
@@ -61,8 +61,7 @@ def _impl(ctx):
 container_flatten = rule(
     attrs = dict({
         "image": attr.label(
-            allow_files = [".tar"],
-            single_file = True,
+            allow_single_file = [".tar"],
             mandatory = True,
         ),
         "_flattener": attr.label(

--- a/container/layers.bzl
+++ b/container/layers.bzl
@@ -165,8 +165,7 @@ def incremental_load(ctx, images, output,
 tools = {
     "incremental_load_template": attr.label(
         default = Label("//container:incremental_load_template"),
-        single_file = True,
-        allow_files = True,
+        allow_single_file = True,
     ),
     "join_layers": attr.label(
         default = Label("//container:join_layers"),

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -102,8 +102,7 @@ def _impl(ctx):
 container_push = rule(
     attrs = dict({
         "image": attr.label(
-            allow_files = [".tar"],
-            single_file = True,
+            allow_single_file = [".tar"],
             mandatory = True,
         ),
         "registry": attr.string(mandatory = True),
@@ -121,8 +120,7 @@ container_push = rule(
         "domain": attr.string(),
         "_tag_tpl": attr.label(
             default = Label("//container:push-tag.sh.tpl"),
-            single_file = True,
-            allow_files = True,
+            allow_single_file = True,
         ),
         "_pusher": attr.label(
             default = Label("@containerregistry//:pusher"),

--- a/container/push.bzl
+++ b/container/push.bzl
@@ -97,7 +97,7 @@ def _impl(ctx):
       image["config"]
   ] + image.get("blobsum", []) + image.get("zipped_layer", []) +
   stamp_inputs + ([image["legacy"]] if image.get("legacy") else []) +
-  list(ctx.attr._pusher.default_runfiles.files)))
+  ctx.attr._pusher.default_runfiles.files.to_list()))
 
 container_push = rule(
     attrs = dict({


### PR DESCRIPTION
Small fixes to `rules_docker` to make them compatible with Bazel 3.2