### PR TITLE
Always use Python 2 when building a Docker image layer

### DIFF
--- a/container/BUILD
+++ b/container/BUILD
@@ -68,6 +68,8 @@ py_binary(
     name = "build_tar",
     srcs = ["build_tar.py", "force_py2.py"],
     srcs_version = "PY2AND3",
+    # We enforce Python 2 here because otherwise the checksum of the generated TAR
+    # will not be consistent. See: https://github.com/databricks/rules_docker/pull/5
     main = "force_py2.py",
     visibility = ["//visibility:public"],
     deps = [

--- a/container/BUILD
+++ b/container/BUILD
@@ -66,8 +66,9 @@ py_binary(
 
 py_binary(
     name = "build_tar",
-    srcs = ["build_tar.py"],
+    srcs = ["build_tar.py", "force_py2.py"],
     srcs_version = "PY2AND3",
+    main = "force_py2.py",
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//third_party/py/gflags",

--- a/container/force_py2.py
+++ b/container/force_py2.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+if __name__ == '__main__':
+    argv = sys.argv
+    path, _ = os.path.split(argv[0])
+    argv[0] = os.path.join(path, 'build_tar.py')
+    argv = ['/usr/bin/env', 'python2'] + argv
+    os.execv(argv[0], argv)


### PR DESCRIPTION
Motivation:

Since Python 3, `tarfile`'s behavior has been changed in a
backward-incompatible way:

- The default format has been changed from `GNU_FORMAT` to `PAX_FORMAT`.
- Even if we enforce `GNU_FORMAT`, the generated `.tar` file is not
  verbatim.

This difference can cause issues when validating the checksum (e.g.
SHA-256) of a Docker image layer when one machine's system default
Python version is different from another, causing mysterious errors such
as:

    invalid diffID for layer N: expected "sha256:...", got "sha256:..."

Modification

- Always run `build_tar.py` with a Python 2 binary.

Result:

- `build_tar` always generates a bit-perfect tarball regardless of the
  current system configuration.