### PR TITLE
Add architecture to container_image

### DIFF
--- a/container/create_image_config.py
+++ b/container/create_image_config.py
@@ -65,6 +65,9 @@ parser.add_argument('--stamp-info-file', action='append', required=False,
 
 _PROCESSOR_ARCHITECTURE = 'arm64' if platform.processor() == 'aarch64' else 'amd64'
 
+parser.add_argument('--architecture', action='store', default=_PROCESSOR_ARCHITECTURE,
+                    help='Target build architecture.')
+
 _OPERATING_SYSTEM = 'linux'
 
 
@@ -131,7 +134,7 @@ def main():
         for (k, v) in six.iteritems(KeyValueToDict(args.env))
       },
       ports=args.ports, volumes=args.volumes, workdir=Stamp(args.workdir)),
-                                  architecture=_PROCESSOR_ARCHITECTURE,
+                                  architecture=args.architecture,
                                   operating_system=_OPERATING_SYSTEM)
 
   with open(args.output, 'w') as fp:

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -200,6 +200,10 @@ def _image_config(ctx, layer_name, entrypoint=None, cmd=None, env=None):
     args += ["--stamp-info-file=%s" % f.path for f in stamp_inputs]
     inputs += stamp_inputs
 
+  # Custom architecture for the layer.
+  if ctx.attr.architecture != "":
+    args.append("--architecture=" + ctx.attr.architecture)
+
   ctx.actions.run(
       executable = ctx.executable.create_image_config,
       arguments = args,
@@ -317,6 +321,7 @@ def _impl(ctx, files=None, file_map=None, empty_files=None, directory=None,
                 container_parts = container_parts)
 
 _attrs = dict({
+    "architecture": attr.string(default = ""),
     "base": attr.label(allow_files = container_filetype),
     "data_path": attr.string(),
     "directory": attr.string(default = "/"),


### PR DESCRIPTION
The flag with the exact same name [exist in latest upstream rules_docker](https://github.com/bazelbuild/rules_docker/blob/master/docs/container.md#container_pull-architecture), but was not implemented in this version. We need this first Milestone 1 of Multiplatform Build (Graviton) support.