### PR TITLE
Replacing tar with tar --no-xattrs to make mac continue to work with Docker version > 4.26

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -184,6 +184,8 @@ function import_config() {
     # Only add files to MISSING once.
     if [ ! -f "${diff_id}.tar" ]; then
       ln -s "${layer}" "${diff_id}.tar"
+      # TEST TEST TEST
+      xattr -c "${diff_id}.tar"
       MISSING+=("${diff_id}.tar")
     fi
   done
@@ -201,11 +203,11 @@ EOF
 
   MISSING+=("config.json" "manifest.json")
 
-  echo ">>>> STEP 5"
+  echo ">>>> STEP 5 ${MISSING[@]}"
   # We minimize reads / writes by symlinking the layers above
   # and then streaming exactly the layers we've established are
   # needed into the Docker daemon.
-  ${TAR} cPh "${MISSING[@]}" | tee image.${TAR} | "${DOCKER}" load
+  ${TAR} cPh "${MISSING[@]}" | tee image.tar | xattr -c | "${DOCKER}" load
   echo ">>>> STEP 6"
 }
 

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -154,6 +154,7 @@ function import_config() {
     local diff_id="$(cat "${RUNFILES}/$1")"
     local layer="${RUNFILES}/$2"
     echo ">>> LAYER IS AT ${layer}"
+    echo ">>> WHERE AM I $(pwd)"
 
     DIFF_IDS+=("\"sha256:${diff_id}\"")
 
@@ -184,7 +185,8 @@ function import_config() {
     # Only create the link if it doesn't exist.
     # Only add files to MISSING once.
     if [ ! -f "${diff_id}.tar" ]; then
-      ln -s "${layer}" "${diff_id}.tar"
+      cp "${layer}" "${diff_id}.tar"
+      # ln -s "${layer}" "${diff_id}.tar"
       # TEST TEST TEST
       xattr -c "${diff_id}.tar"
       MISSING+=("${diff_id}.tar")

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -114,6 +114,8 @@ function find_diffbase() {
 }
 
 function import_config() {
+  echo ">>>> STEP 1"
+
   # Create an image from the image configuration file.
   local name="${RUNFILES}/$1"
   shift 1
@@ -143,6 +145,8 @@ function import_config() {
     ALL_QUOTED+=("\"${diff_id}.tar\"")
   done
 
+  echo ">>>> STEP 2"
+
   # Starting from our legacy diffbase, figure out which
   # additional layers the Docker daemon already has.
   while test $# -gt 0
@@ -162,6 +166,8 @@ function import_config() {
     ALL_QUOTED+=("\"${diff_id}.tar\"")
     shift 2
   done
+
+  echo ">>>> STEP 3"
 
   # Set up the list of layers we actually need to load,
   # from the cut-off established above.
@@ -191,12 +197,16 @@ function import_config() {
 }]
 EOF
 
+  echo ">>>> STEP 4"
+
   MISSING+=("config.json" "manifest.json")
 
+  echo ">>>> STEP 5"
   # We minimize reads / writes by symlinking the layers above
   # and then streaming exactly the layers we've established are
   # needed into the Docker daemon.
   ${TAR} cPh "${MISSING[@]}" | tee image.${TAR} | "${DOCKER}" load
+  echo ">>>> STEP 6"
 }
 
 function tag_layer() {

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -28,6 +28,7 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 DOCKER="${DOCKER:-docker}"
 
+COPYFILE_DISABLE=1
 TAR=(tar --xattrs)
 
 # Create temporary files in which to record things to clean up.
@@ -219,7 +220,7 @@ EOF
   ${TAR} cPh "${MISSING[@]}" > image.tar
   chmod +w image.tar
   xattr -c image.tar
-  "${DOCKER}" load < image.tar
+  "${DOCKER}" load -i image.tar
   # ${TAR} cPh "${MISSING[@]}" | tee image.tar | xattr -c | "${DOCKER}" load
   echo ">>>> STEP 6"
 }

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -28,7 +28,7 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 DOCKER="${DOCKER:-docker}"
 
-TAR=(${TAR} --xattrs)
+TAR=(tar --xattrs)
 
 # Create temporary files in which to record things to clean up.
 TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'rules_docker_files')"

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -209,12 +209,7 @@ EOF
   # and then streaming exactly the layers we've established are
   # needed into the Docker daemon.
   # Explicitly ensure when generating final tar, we set --no-xattrs to avoid macOS xattr issues.
-  tar --no-xattrs -cPh "${MISSING[@]}" > image.tar
-  # if [ "$(uname)" == "Darwin" ]; then
-  #   chmod +w image.tar
-  #   xattr -c image.tar
-  # fi
-  "${DOCKER}" load -i image.tar
+  tar --no-xattrs -cPh "${MISSING[@]}" | tee image.tar | "${DOCKER}" load
 }
 
 function tag_layer() {

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -153,6 +153,7 @@ function import_config() {
   do
     local diff_id="$(cat "${RUNFILES}/$1")"
     local layer="${RUNFILES}/$2"
+    echo ">>> LAYER IS AT ${layer}"
 
     DIFF_IDS+=("\"sha256:${diff_id}\"")
 

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -188,8 +188,8 @@ function import_config() {
       cp "${layer}" "${diff_id}.tar"
       # ln -s "${layer}" "${diff_id}.tar"
       # TEST TEST TEST
-      chmod +w "${diff_id}.tar"
-      xattr -c "${diff_id}.tar"
+      # chmod +w "${diff_id}.tar"
+      # xattr -c "${diff_id}.tar"
       MISSING+=("${diff_id}.tar")
     fi
   done
@@ -207,11 +207,20 @@ EOF
 
   MISSING+=("config.json" "manifest.json")
 
+  for file in "${MISSING[@]}"; do
+    chmod +w "${file}"
+    xattr -c "${file}"
+  done
+
   echo ">>>> STEP 5 ${MISSING[@]}"
   # We minimize reads / writes by symlinking the layers above
   # and then streaming exactly the layers we've established are
   # needed into the Docker daemon.
-  ${TAR} cPh "${MISSING[@]}" | tee image.tar | xattr -c | "${DOCKER}" load
+  ${TAR} cPh "${MISSING[@]}" > image.tar
+  chmod +w image.tar
+  xattr -c image.tar
+  "${DOCKER}" load < image.tar
+  # ${TAR} cPh "${MISSING[@]}" | tee image.tar | xattr -c | "${DOCKER}" load
   echo ">>>> STEP 6"
 }
 

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -188,6 +188,7 @@ function import_config() {
       cp "${layer}" "${diff_id}.tar"
       # ln -s "${layer}" "${diff_id}.tar"
       # TEST TEST TEST
+      chmod +w "${diff_id}.tar"
       xattr -c "${diff_id}.tar"
       MISSING+=("${diff_id}.tar")
     fi

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -28,6 +28,8 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 DOCKER="${DOCKER:-docker}"
 
+TAR=(${TAR} --xattrs)
+
 # Create temporary files in which to record things to clean up.
 TEMP_FILES="$(mktemp -t 2>/dev/null || mktemp -t 'rules_docker_files')"
 TEMP_IMAGES="$(mktemp -t 2>/dev/null || mktemp -t 'rules_docker_images')"
@@ -87,7 +89,7 @@ EOF
 EOF
 
   set -o pipefail
-  tar c config.json manifest.json | "${DOCKER}" load 2>/dev/null | cut -d':' -f 2- >> "${TEMP_IMAGES}"
+  ${TAR} c config.json manifest.json | "${DOCKER}" load 2>/dev/null | cut -d':' -f 2- >> "${TEMP_IMAGES}"
 }
 
 function find_diffbase() {
@@ -194,7 +196,7 @@ EOF
   # We minimize reads / writes by symlinking the layers above
   # and then streaming exactly the layers we've established are
   # needed into the Docker daemon.
-  tar cPh "${MISSING[@]}" | tee image.tar | "${DOCKER}" load
+  ${TAR} cPh "${MISSING[@]}" | tee image.${TAR} | "${DOCKER}" load
 }
 
 function tag_layer() {


### PR DESCRIPTION
Context: https://databricks.atlassian.net/browse/ES-1094678

How to test:
* Docker desktop (macOS) update to v4.27
* Checkout the test version of `rules_docker` in your local universe
```
# Go to universe WORKSPACE file and update to
http_archive(
    name = "io_bazel_rules_docker",
    patch_args = ["-p1"],
    patches = ["//bazel/patches:io_bazel_rules_docker.six-1.9.patch"],
    # This might need to be changed locally if you have error pulling. macOS might tamper with its sha, so download the zip locally yourself first and run sha256sum on it to get the sha to be copied here
    sha256 = "0b23460c018678a8d646101762bd29dbfbb7224ab89221edb5a2bff13b5fc857",  # <-- changed
    strip_prefix = "rules_docker-3243fd53c0a12036741d6f7ce4e254bf48419708",  # <-- changed
    urls = [
        # Github supports downloading zip like this using a commit.
        "https://github.com/databricks/rules_docker/archive/3243fd53c0a12036741d6f7ce4e254bf48419708.zip", # <-- changed
    ],
)

# Go to universe .bazeldownloader file and temporary replace
block *
# With the following
allow github.com
# So we can fetch from Github the zip for testing.
```
* Run `bazel run //docker-images/tidb:tidb-all-in-one-brickstore_binary_loader`.

Before:
```
$ bazel run //docker-images/tidb:tidb-all-in-one-brickstore_binary_loader
...
lsetxattr com.apple.provenance /db0e59396abbd3cd3136c376a49a947aa8022c8927d2f6d383c26ee5b07d6864.tar: operation not supported
tar: Write error
```

After:
```
$ bazel run //docker-images/tidb:tidb-all-in-one-brickstore_binary_loader
...
8264e3874cd42cb149ae14655ff843863eab76d2c5c61a1c742e6676019ce460%
```

Also double check you can run the image without problem.