### PR TITLE
Fix mktemp behavior on macOS

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -203,10 +203,13 @@ EOF
   if [ "$(uname)" == "Darwin" ]; then
     echo "Cleaning xattrs from files on macOS..."
     for file in "${MISSING[@]}"; do
+      echo ">>> Cleaning for file ${file}"
       chmod +w "${file}"
       xattr -c "${file}"
     done
   fi
+
+  echo ">>> STEP 1"
 
   # We minimize reads / writes by symlinking the layers above
   # and then streaming exactly the layers we've established are
@@ -214,7 +217,12 @@ EOF
   # Explicitly ensure when generating final tar, we set --no-xattrs to avoid macOS xattr issues.
   DOCKER_LOAD_OUTPUT_FILE=$(mktemp -t 2>/dev/null)
   echo "${DOCKER_LOAD_OUTPUT_FILE}" >> "${TEMP_FILES}"
+
+  echo ">>> STEP 2: ${DOCKER_LOAD_OUTPUT_FILE}"
+
   tar --no-xattrs -cPh "${MISSING[@]}" | tee image.tar | "${DOCKER}" load | tee "${DOCKER_LOAD_OUTPUT_FILE}"
+
+  echo ">>> STEP 3"
   IMAGE_ID=$(cat $DOCKER_LOAD_OUTPUT_FILE | awk -F'sha256:' '{print $2}')
   echo "Tagging ${IMAGE_ID} as ${TAG}"
   "${DOCKER}" tag sha256:${IMAGE_ID} ${TAG}


### PR DESCRIPTION
Context: https://databricks.atlassian.net/browse/ES-1302418?focusedCommentId=5834199
Fix breakage introduced by PR https://github.com/databricks/rules_docker/pull/12

How to test that is works now:

Follow steps in https://github.com/databricks/rules_docker/pull/11#issue-2609952948, but use the latest sha from this PR. You should see that running the image load will yield a SHA (vs after the breaking PR it causes no SHA printed + exit 1)