### PR TITLE
[rbe] Local registry: build config diff ids from layers, use http server and better runfiles propagation

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -273,7 +273,7 @@ function import_config() {
   fi
 
   # Load and pull the image from the local registry
-  local ref=$("${RUNFILES}/%{loader_tool}" "${DOCKER}" "${config_and_layers[@]}")
+  local ref=$(RUNFILES_DIR="${RUNFILES}" RUNFILES_MANIFEST_FILE= "${RUNFILES}/%{loader_tool}" "${DOCKER}" "${config_and_layers[@]}")
 
   # Prints to keep compatibility on other scripts parsing this output
   # since 'docker load' used to print the sha

--- a/container/loader_tool.py
+++ b/container/loader_tool.py
@@ -217,7 +217,7 @@ def retry_with_backoff(fn, friendly_name, max_retries=5, initial_backoff_secs=1)
             fn()
         except Exception as e:
             print("%s failed with" % friendly_name, e, file=sys.stderr)
-            print("Will retry %d more time(s)" % (max_retries-i-1))
+            print("Will retry %d more time(s)" % (max_retries-i-1), file=sys.stderr)
             time.sleep(backoff_secs)
             backoff_secs = 2 * backoff_secs
 

--- a/container/loader_tool.py
+++ b/container/loader_tool.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
 
     docker_binary = args.docker_binary
     registry = DockerV2Registry(args.config_path, *args.layer_pairs)
-    httpd = http.server.HTTPServer(("127.0.0.1", 0), registry.handler())
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), registry.handler())
     ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
     with tempfile.NamedTemporaryFile() as certfile:
         certfile.write(SSL_CERT)


### PR DESCRIPTION
The local registry gets the image config as input, which contains the hashes of all the layers inside of the image.
We were simply returning it but it turns out the hashes of the layers in the config does not always match the actual layers.
This is caused by a weird interaction in Databricks internal rules where we have a docker layer as a parent of a docker base like `docker_layer -> docker_base -> docker_layer`.

Essentially, if the docker layer changes, we are required to rebuild the docker_base but there is nothing enforcing that today (see https://github.com/databricks-eng/universe/blob/bf55a02cb20c5bb72992a4bb401212bea69f9397/bazel/rules/docker.bzl#L2051).

When that happens, we get errors like the ones seen on:
https://runbot-ci.cloud.databricks.com/build/Unit-Compile-Pr/run-logs/45377642
```
layers from manifest don't match image configuration
```

So to workaround this we make the behaviour of the loader_tool to be the same as the original incremental loader: we overwrite the hashes in the config using the values computed from the actual layers:
https://github.com/databricks/rules_docker/blob/da6dc62cf6ac1abdc0e5c4fbfcff19fdc159e736/container/incremental_load.sh.tpl#L75

-----

Also we use an ThreadingHTTPServer and retry pulls to increase reliability (to avoid errors like):
```
error pulling image configuration: download failed after attempts=6: net/http: TLS handshake timeout
```
https://runbot-ci.cloud.databricks.com/module-results/30996083051?runId=45355617

----

Lastly, we also make sure to pass down `RUNFILES` from the incremental loader script into the loader binary and make sure to unset RUNFILES_MANIFEST_FILE since our scala rules don't set those.
